### PR TITLE
chore: build on Windows

### DIFF
--- a/.github/workflows/java-ci.yaml
+++ b/.github/workflows/java-ci.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         java_version: [ '17' ]
-        os: [ 'ubuntu-latest' ] #  'windows-latest' later
+        os: [ 'ubuntu-latest', 'windows-latest' ]
 
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
Unfortunately, the build on Windows takes a lot more time than on Ubuntu.