### PR TITLE
chore(build): publish to maven central

### DIFF
--- a/.github/workflows/publish-release-maven-central.yml
+++ b/.github/workflows/publish-release-maven-central.yml
@@ -1,0 +1,70 @@
+# This workflow uploads the releases to the Maven Central Repository
+name: Publish Release to Maven Central
+
+on:
+  release:
+    types:
+      - released
+      - prereleased
+
+env:
+  SEMANTIC_VERSION: ${{ github.event.release.tag_name }}
+  SONATYPE_PROFILE_ID: 33839da457341f
+
+jobs:
+  upload-maven-central:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@2c7a4878f5d120bd643426d54ae1209b29cc01a3 # tag=v3
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'gradle'
+
+      - name: Build and Sign packages
+        run: ./gradlew --parallel signMavenPublication
+        env:
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PRIVATE_KEY_SECRET }}
+
+      - name: Create Staging Repository
+        id: create-staging-repo
+        run: |
+          ID=`echo "<promoteRequest><data><description>Created from GitHub Action for version $SEMANTIC_VERSION</description></data></promoteRequest>" \
+              | curl -X POST \
+                  -d @- \
+                  -u $SDA_SONATYPE_USER:$SDA_SONATYPE_PASSWORD \
+                  -H "Content-Type:application/xml" \
+                  https://oss.sonatype.org/service/local/staging/profiles/$SONATYPE_PROFILE_ID/start \
+              | sed -n 's:.*<stagedRepositoryId>\(.*\)</stagedRepositoryId>.*:\1:p'`
+          echo "::set-output name=STAGING_PROFILE_ID::$ID"
+        env:
+          SDA_SONATYPE_USER: ${{ secrets.SDA_SONATYPE_USER }}
+          SDA_SONATYPE_PASSWORD: ${{ secrets.SDA_SONATYPE_PASSWORD }}
+
+      - name: Upload to Maven Central
+        run: ./gradlew -x signMavenPublication publishMavenPublicationToMavenCentralRepository # FIXME DO NOT RELEASE yet, include the next task later: closeAndReleaseRepository
+        env:
+          SDA_SONATYPE_USER: ${{ secrets.SDA_SONATYPE_USER }}
+          SDA_SONATYPE_PASSWORD: ${{ secrets.SDA_SONATYPE_PASSWORD }}
+          SONATYPE_STAGING_REPOSITORY_ID: ${{ steps.create-staging-repo.outputs.STAGING_PROFILE_ID }}
+
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          fields: workflow,job,commit,repo,ref,author,took
+          custom_payload: |
+            {
+              username: 'Maven Central Upload',
+              icon_emoji: ':coffin-dance:',
+              attachments: [{
+                color: 'danger',
+                text: `Maven Central Upload of ${{ github.event.release.tag_name }} failed!\n\nWorkflow ${process.env.AS_WORKFLOW}`,
+              }]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+        if: failure()

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ plugins {
   id 'io.spring.dependency-management' version '1.0.13.RELEASE'
   id 'org.sonarqube' version '3.4.0.2513'
   id 'project-report'
+  id 'io.codearte.nexus-staging' version '0.30.0'
 }
 
 ext {
@@ -103,7 +104,7 @@ subprojects {
           }
           pom {
             name = project.group + ":" + project.name
-            description = 'A libraries to bootstrap services easily that follow the patterns and specifications promoted by the SDA SE'
+            description = 'A library to bootstrap services easily that follow the patterns and specifications promoted by the SDA SE'
             url = 'https://github.com/SDA-SE/sda-spring-boot-commons'
 
             licenses {
@@ -121,6 +122,14 @@ subprojects {
             issueManagement {
               system = 'GitHub'
               url = 'https://github.com/SDA-SE/sda-spring-boot-commons/issues'
+            }
+
+            developers {
+              developer {
+                id = 'maintainer'
+                name = 'SDA SE Open Industry Solutions Maintainer'
+                email = 'sda-dropwizard-commons@sda.se' // FIXME need a better matching address here
+              }
             }
 
             scm {
@@ -144,6 +153,20 @@ subprojects {
             password System.getenv('SDA_NEXUS_PASSWORD')
           }
         }
+        maven {
+          name 'mavenCentral'
+          def releasesRepoUrl =
+              System.getenv('SONATYPE_STAGING_REPOSITORY_ID')
+                  ? "https://oss.sonatype.org/service/local/staging/deployByRepositoryId/${System.getenv('SONATYPE_STAGING_REPOSITORY_ID')}"
+                  : "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+          def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
+          url = version.endsWith('-SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+
+          credentials {
+            username System.getenv('SDA_SONATYPE_USER')
+            password System.getenv('SDA_SONATYPE_PASSWORD')
+          }
+        }
       }
     }
 
@@ -164,6 +187,16 @@ subprojects {
 }
 
 wrapper { gradleVersion = '7.4.2' }
+
+// Automatically close and release the staging repository that gets created
+// during the upload to maven central.
+nexusStaging {
+  username System.getenv('SDA_SONATYPE_USER')
+  password System.getenv('SDA_SONATYPE_PASSWORD')
+  packageGroup "org.sdase.commons.spring.boot"
+  // Read the stagingRepositoryId from the environment
+  stagingRepositoryId.set(System.getenv('SONATYPE_STAGING_REPOSITORY_ID'))
+}
 
 // Reconfigure the testReport task to display the results of all modules into a single report
 task testReport(type: TestReport) {


### PR DESCRIPTION
This is a first step on the way to maven central. `closeAndReleaseRepository` is not executed with this PR. The result is hopefully, that we can check that the staging repository is created and filled with modules. We should also see the validation result. But no artifacts should be public afterwards.

We may want to get a dedicated email address for the project or create some address that can be used for multiple projects.