### PR TITLE
fix(deps): bump spring-boot-dependencies from 2.7.5 to 2.7.6

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -9,7 +9,7 @@ javaPlatform {
 ext {
   awaitalityVersion = '4.2.0'
   logbackContribVersion = '0.1.5'
-  springBootVersion = '2.7.5'
+  springBootVersion = '2.7.6'
   springCloudVersion = '2021.0.5'
   scalaVersion = '2.13.10'
 }


### PR DESCRIPTION
## Release Notes

https://github.com/spring-projects/spring-boot/releases/tag/v2.7.6