### PR TITLE
Document security hardening and enable security for sda platform

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,12 +5,12 @@ specifications promoted by the SDA SE.
 
 ## Features
 
-| **Starter**                                     | **Description**                                                                                                                                                       |
-|-------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [sda-commons-starter-web](web/index.md)         | Provides the required features for an SDA-compliant microservice including OIDC authentication, OPA authorization, health checks, OpenTracing and Prometheus metrics. |
-| [sda-commons-starter-mongodb](mongodb/index.md) | Provides default configuration based on the `org.springframework.boot:spring-boot-starter-data-mongodb`                                                               |
-| [sda-commons-starter-kafka](kafka/index.md)     | Provides default producer und consumer configuration based on `org.springframework.kafka:spring-kafka`                                                                |
-| [sda-commons-starter-s3](s3/index.md)           | Provides features for dealing with the Amazon S3 file storage                                                                                                         |
+| **Starter**                                     | **Description**                                                                                                                                                                                                     |
+|-------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [sda-commons-starter-web](web/index.md)         | Provides the required features for an SDA-compliant microservice including OIDC authentication, OPA authorization, health checks, OpenTelemetry, Prometheus metrics and [hardening the service](security/index.md). |
+| [sda-commons-starter-mongodb](mongodb/index.md) | Provides default configuration based on the `org.springframework.boot:spring-boot-starter-data-mongodb`                                                                                                             |
+| [sda-commons-starter-kafka](kafka/index.md)     | Provides default producer und consumer configuration based on `org.springframework.kafka:spring-kafka`                                                                                                              |
+| [sda-commons-starter-s3](s3/index.md)           | Provides features for dealing with the Amazon S3 file storage                                                                                                                                                       |
 
 The provided documentation aims to provide SDA-specific information.
 All other information are referenced in the Spring and [Spring Boot documentation](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#documentation).

--- a/docs/security/index.md
+++ b/docs/security/index.md
@@ -32,7 +32,7 @@ The HTTP method `TRACE` is disabled by default to mitigate [Cross Site Tracing](
 
 ## Risk: Loss of source IP address
 
-We expect, the services built with sda-spring-boot-commons are deployed behind a proxy, e.g. an
+We expect, that services built with sda-spring-boot-commons are deployed behind a proxy, e.g. an
 Ingress in Kubernetes.
 
 This library is configured by default to consider `X-Forwarded-*` headers to identify the original

--- a/docs/security/index.md
+++ b/docs/security/index.md
@@ -1,0 +1,69 @@
+# Security Hardening
+
+sda-spring-boot-commons changes some default configuration for security reasons.
+This document provides a brief overview about the addressed risks.
+
+## Risk: Accessing critical resources from untrusted environments
+
+To avoid exposing internal resources, Spring Boot Actuator is configured to listen on a separate
+port.
+Health, metrics and other sensitive information can't be exposed to the internet by accident, e.g.
+by missing to exclude the actuator path.
+
+Custom critical resources can be exposed at the management port by implementing
+`org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint` or
+`org.springframework.boot.actuate.endpoint.web.annotation.ControllerEndpoint`.
+Note that there is an [open discussion](https://github.com/spring-projects/spring-boot/issues/31768)
+about these annotations.
+As long as they are not deprecated, it is suggested to use them because the use is most similar to
+controllers used in regular REST APIs.
+
+## Risk: Root start
+
+If the service is started with extended privileges as the root user, an attacker can more easily
+attack the operating system after taking over from the container.
+
+The default configuration is capable to run as no root, listening to ports 8080 and 8081.
+Deployment checks must ensure, that the container is not configured with a root user.
+
+## Risk: Exploitation of HTTP methods
+
+The HTTP method `TRACE` is disabled by default to mitigate [Cross Site Tracing](https://owasp.org/www-community/attacks/Cross_Site_Tracing).
+
+## Risk: Loss of source IP address
+
+We expect, the services built with sda-spring-boot-commons are deployed behind a proxy, e.g. an
+Ingress in Kubernetes.
+
+This library is configured by default to consider `X-Forwarded-*` headers to identify the original
+caller.
+
+## Risk: Detection of confidential components
+
+Knowing the components used in a software makes it easier to look for and exploit specific CVEs.
+
+Custom error handlers and other configurations are used to avoid identifiable default output from
+the framework and its components.
+
+## Risk: Lack of visibility
+
+If there is no visibility, there is no response to an abusive action and attackers can explore risks
+undisturbed.
+
+Logs are written to standard out by default to comply with Kubernetes environments.
+Prometheus metrics are exposed as expected by SDA environments.
+
+## Risk: Buffer Overflow
+
+The size of request and response headers is limited to 8KiB.
+
+## Header
+
+By configuring the default headers, the following risks are addressed:
+
+- Cross-Site Scripting
+- Content interpretation by the browser
+- Content loading in Flash and PDFs
+- Clickjacking
+- Sharing visited URLs with third parties
+- Abuse from Cross-Origin Resource Sharing

--- a/docs/web/index.md
+++ b/docs/web/index.md
@@ -11,8 +11,7 @@ Features:
   - [Jackson Object Mapping](#jackson)
   - [Monitoring](#monitoring)
   - [Tracing](#tracing)
-  - [Health Checks](#health-checks)
-  - [Testing](#testing)
+  - [Health Checks](#health-checks--actuator)
   - [Logging](#logging)
 
 Based on:
@@ -41,6 +40,7 @@ Based on:
 | `oidc.client.id` _string_                | The client ID for the registration.                                                                                                     | ``                                                                   | `exampleClient`                                              | `OPA_CLIENT_ID`                 |
 | `oid.client.secret` _string_             | The Client secret of the registration.                                                                                                  | ``                                                                   | `s3cret`                                                     | `OIDC_CLIENT_SECRET`            |
 | `oidc.client.issuer.uri` _string_        | URI that can either be an OpenID Connect discovery endpoint or an OAuth 2.0 Authorization Server Metadata endpoint defined by RFC 8414. | ``                                                                   | `https://keycloak.sdadev.sda-se.io/auth/realms/exampleRealm` | `OIDC_CLIENT_ISSUER_URI`        |
+| `cors.allowed-origin-patterns` _string_  | Comma separated list of URL patterns for which CORS requests are allowed.                                                               | _none allowed_                                                       | `https://*.all-subdomains.com, https://static-domain.com`    | `CORS_ALLOWEDORIGINPATTERNS`    |
 
 For further information have a look at the [Spring Boot documentation](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#documentation).
 
@@ -111,9 +111,10 @@ public class MyConstraints extends AbstractConstraints {
 ```java
 @RestController
 public class AuthTestApp {
-
-  @Autowired private MyConstraints myConstraints;
-  ...
+    @Autowired
+    private MyConstraints myConstraints;
+    // ...
+}
 ```
 
 ### Testing
@@ -176,7 +177,7 @@ allow {
 # set some example constraints 
 constraint1 := true                # always true
 constraint2 := [ "v2.1", "v2.2" ]  # always an array of "v2.1" and "v2.2"
-constraint3[token.payload.sub].    # always a set that contains the 'sub' claim from the token
+constraint3[token.payload.sub]     # always a set that contains the 'sub' claim from the token
                                    # or is empty if no token is present
 
 ```
@@ -543,6 +544,3 @@ The Spring Boot default is enabled.
     * `classpath:org/sdase/commons/spring/logging/logback-json.xml` for Json Logging
   * Example: `classpath:org/sdase/commons/spring/logging/logback-json.xml`
   * Default: `org/springframework/boot/logging/logback/defaults.xml`
-
-
-## Testing

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -14,6 +14,7 @@ nav:
   - S3: s3/index.md
   - MongoDB: mongodb/index.md
   - Kafka: kafka/index.md
+  - Security Hardening: security/index.md
 
 # Always include the techdocs-core plugin, otherwise it's not possible to
 # display the documentation in Backstage. We don't support other plugins

--- a/sda-commons-web-autoconfigure/src/main/java/org/sdase/commons/spring/boot/web/EnableSdaPlatform.java
+++ b/sda-commons-web-autoconfigure/src/main/java/org/sdase/commons/spring/boot/web/EnableSdaPlatform.java
@@ -17,6 +17,7 @@ import org.sdase.commons.spring.boot.web.client.EnableSdaClients;
 import org.sdase.commons.spring.boot.web.docs.EnableSdaDocs;
 import org.sdase.commons.spring.boot.web.jackson.EnableSdaRestGuide;
 import org.sdase.commons.spring.boot.web.monitoring.EnableSdaMonitoring;
+import org.sdase.commons.spring.boot.web.security.EnableSdaWebSecurity;
 import org.springframework.context.annotation.Import;
 
 /**
@@ -38,8 +39,9 @@ import org.springframework.context.annotation.Import;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-@EnableSdaDocs
 @EnableSdaRestGuide
+@EnableSdaWebSecurity
+@EnableSdaDocs
 @EnableSdaSecurity
 @EnableSdaClients
 @EnableSdaAsyncWithRequestContext


### PR DESCRIPTION
- [x] wait for #162 to be merged

Note: Security is already available for auto configured services. Users of `@EnableSdaPlatform` get the security features as well now.