### PR TITLE
fix: use default trust manager if no custom certificates are mounted

### DIFF
--- a/sda-commons-cacertificates/src/main/java/org/sdase/commons/cacertificates/CaCertificatesConfiguration.java
+++ b/sda-commons-cacertificates/src/main/java/org/sdase/commons/cacertificates/CaCertificatesConfiguration.java
@@ -28,10 +28,9 @@ public class CaCertificatesConfiguration {
   @Bean
   @ConditionalOnMissingBean
   public SSLContext sslContext() {
-    return certificateReader
-        .readCertificates() // pem content as strings
-        .map(SslUtil::createTruststoreFromPemKey) // a keystore instance that have certs loaded
-        .map(SslUtil::createSslContext) // the sslContext created with the previous keystore
-        .orElse(null);
+    var certificatesAsString =
+        certificateReader.readCertificates().orElse(null); // pem content as strings
+    var keyStoreOrNull = SslUtil.createTruststoreFromPemKey(certificatesAsString);
+    return SslUtil.createSslContext(keyStoreOrNull);
   }
 }

--- a/sda-commons-cacertificates/src/main/java/org/sdase/commons/cacertificates/ssl/SslUtil.java
+++ b/sda-commons-cacertificates/src/main/java/org/sdase/commons/cacertificates/ssl/SslUtil.java
@@ -25,6 +25,7 @@ import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.X509TrustedCertificateBlock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.lang.Nullable;
 
 public class SslUtil {
 
@@ -34,7 +35,7 @@ public class SslUtil {
 
   private SslUtil() {}
 
-  public static SSLContext createSslContext(KeyStore keystore) {
+  public static SSLContext createSslContext(@Nullable KeyStore keystore) {
     try {
       var trustManagers = new TrustManager[] {createCompositeTrustManager(keystore)};
 
@@ -47,7 +48,10 @@ public class SslUtil {
     }
   }
 
-  public static KeyStore createTruststoreFromPemKey(String certificateAsString) {
+  public static KeyStore createTruststoreFromPemKey(@Nullable String certificateAsString) {
+    if (certificateAsString == null) {
+      return null;
+    }
     try (var parser = new PEMParser(new StringReader(certificateAsString))) {
       var keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
       keyStore.load(null, null);

--- a/sda-commons-cacertificates/src/main/java/org/sdase/commons/cacertificates/ssl/SslUtil.java
+++ b/sda-commons-cacertificates/src/main/java/org/sdase/commons/cacertificates/ssl/SslUtil.java
@@ -14,6 +14,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
 import java.util.Arrays;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
@@ -118,10 +119,16 @@ public class SslUtil {
     return null;
   }
 
-  private static TrustManager createCompositeTrustManager(KeyStore keystore) {
+  private static TrustManager createCompositeTrustManager(@Nullable KeyStore keystore) {
     String defaultTrustManagerAlgorithm = TrustManagerFactory.getDefaultAlgorithm();
-    X509TrustManager defaultTrustManager = getTrustManager(defaultTrustManagerAlgorithm, null);
-    X509TrustManager customTrustManager = getTrustManager(defaultTrustManagerAlgorithm, keystore);
-    return new CompositeX509TrustManager(Arrays.asList(defaultTrustManager, customTrustManager));
+    var trustManagersList = new ArrayList<X509TrustManager>();
+    trustManagersList.add(getTrustManager(defaultTrustManagerAlgorithm, null));
+
+    // using a null key store will create another defaultTrustManager with same settings
+    if (keystore != null) {
+      // add a trust manager created from the given keystore
+      trustManagersList.add(getTrustManager(defaultTrustManagerAlgorithm, keystore));
+    }
+    return new CompositeX509TrustManager(trustManagersList);
   }
 }

--- a/sda-commons-cacertificates/src/test/java/org/sdase/commons/cacertificates/CaCertificatesBundleHttpsIT.java
+++ b/sda-commons-cacertificates/src/test/java/org/sdase/commons/cacertificates/CaCertificatesBundleHttpsIT.java
@@ -48,6 +48,14 @@ class CaCertificatesBundleHttpsIT {
   }
 
   @Test
+  void shouldHttpsOK200WithDefaultTrustStore() throws Exception {
+    // The default context should be created with an empty certificate bundle
+    SSLContext sslContext = SslUtil.createSslContext(SslUtil.createTruststoreFromPemKey(null));
+    assertThat(callSecureEndpointWithSSLContext(sslContext).getStatusLine().getStatusCode())
+        .isEqualTo(200);
+  }
+
+  @Test
   void shouldMakeHttpsOK200withCustomTrustStore() throws Exception {
 
     var certificateReader = new CertificateReader(Paths.get("src", "test", "resources").toString());

--- a/sda-commons-cacertificates/src/test/java/org/sdase/commons/cacertificates/CaCertificatesConfigurationTest.java
+++ b/sda-commons-cacertificates/src/test/java/org/sdase/commons/cacertificates/CaCertificatesConfigurationTest.java
@@ -14,9 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest(
-    classes = TestApp.class,
-    properties = {"sda.caCertificates.certificatesDir=src/test/resources"})
+@SpringBootTest(classes = TestApp.class)
 class CaCertificatesConfigurationTest {
 
   @Autowired SSLContext sslContext;

--- a/sda-commons-cacertificates/src/test/java/org/sdase/commons/cacertificates/CustomSSLContextTest.java
+++ b/sda-commons-cacertificates/src/test/java/org/sdase/commons/cacertificates/CustomSSLContextTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022- SDA SE Open Industry Solutions (https://www.sda.se)
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package org.sdase.commons.cacertificates;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.net.ssl.SSLContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(
+    classes = TestApp.class,
+    properties = {"sda.caCertificates.certificatesDir=src/test/resources"})
+class CustomSSLContextTest {
+
+  @Autowired SSLContext sslContext;
+
+  @Test
+  void shouldCreateSSlContextBean() {
+    assertThat(sslContext).isNotNull();
+  }
+}

--- a/sda-commons-cacertificates/src/test/java/org/sdase/commons/cacertificates/DefaultSSLContextTest.java
+++ b/sda-commons-cacertificates/src/test/java/org/sdase/commons/cacertificates/DefaultSSLContextTest.java
@@ -15,7 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(classes = TestApp.class)
-class CaCertificatesConfigurationTest {
+class DefaultSSLContextTest {
 
   @Autowired SSLContext sslContext;
 


### PR DESCRIPTION
Spring boot does not allow beans to be null, this will use only the default trust store even if no certificate is mounted in the configured path.
The current behaviour is that the application will fail to start if no certificates are provided

- [x] Test in a [service](https://github.com/SDA-SE/email-transformation-orchestrator/pull/29/commits/6542bfa3d72758da3cd4f962f374b82ef40adb9f)