### PR TITLE
fix(jackson): write invalid Json when errors happen while serialization

### DIFF
--- a/sda-commons-web-autoconfigure/src/main/java/org/sdase/commons/spring/boot/web/jackson/SdaObjectMapperConfiguration.java
+++ b/sda-commons-web-autoconfigure/src/main/java/org/sdase/commons/spring/boot/web/jackson/SdaObjectMapperConfiguration.java
@@ -7,6 +7,7 @@
  */
 package org.sdase.commons.spring.boot.web.jackson;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -34,6 +35,7 @@ public class SdaObjectMapperConfiguration {
             SerializationFeature.FAIL_ON_EMPTY_BEANS,
             SerializationFeature.WRITE_DATES_AS_TIMESTAMPS,
             SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS,
+            JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT,
             DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
             DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES,
             DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)


### PR DESCRIPTION
These errors are the only way to identify a serialisation error on consumer side when e.g. a Json is written directly to the response output stream. Streaming data directly from a source (e.g. a MongoCursor) into the response as chunked encoding is valuable to minimize memory resources but may lead to not identifiable errors (e.g. while mapping from entity model to API model) when the ObjectMapper creates a valid Json after the error when the generator is closed.