### PR TITLE
fix(deps): bump io.swagger.core.v3:swagger-annotations

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     }
     api "ch.qos.logback.contrib:logback-json-classic:${logbackContribVersion}"
     api "ch.qos.logback.contrib:logback-jackson:${logbackContribVersion}"
-    api 'org.springdoc:springdoc-openapi-webmvc-core:1.6.15'
+    api 'org.springdoc:springdoc-openapi-webmvc-core:1.7.0'
     api 'io.github.classgraph:classgraph:4.8.157'
     api 'javax.ws.rs:javax.ws.rs-api:2.1.1'
     api 'io.micrometer:micrometer-registry-prometheus:1.10.6'

--- a/sda-commons-error/build.gradle
+++ b/sda-commons-error/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-  api 'io.swagger.core.v3:swagger-annotations:2.2.8'
+  api 'io.swagger.core.v3:swagger-annotations:2.2.9'
 }


### PR DESCRIPTION
Bumps io.swagger.core.v3:swagger-annotations from 2.2.8 to 2.2.9.
Bumps org.springdoc:springdoc-openapi-webmvc-core from 1.6.15 to 1.7.0
---
updated-dependencies:
- dependency-name: io.swagger.core.v3:swagger-annotations dependency-type: direct:production update-type: version-update:semver-patch ...

Fixes: https://github.com/SDA-SE/sda-spring-boot-commons/pull/226