### PR TITLE
chore: accept/ignore CVE-2016-1000027

### DIFF
--- a/.github/workflows/ignore-policy.rego
+++ b/.github/workflows/ignore-policy.rego
@@ -5,7 +5,8 @@ import data.lib.trivy
 default ignore = false
 
 ignore_cves := {
-  "CVE-2022-1471" # org.yaml:snakeyaml.1.33
+  "CVE-2022-1471", # org.yaml:snakeyaml.1.33
+  "CVE-2016-1000027" # org.springframework:spring-web:5.3.29
 }
 
 ignore {


### PR DESCRIPTION
We are not affected because we do not use HTTP invokers and do not provide them publicly.