### PR TITLE
fix(sda-commons-starter-web): replace `server.max-http-header-size` w…

### DIFF
--- a/sda-commons-starter-web/src/main/resources/org/sdase/commons/spring/boot/web/defaults.properties
+++ b/sda-commons-starter-web/src/main/resources/org/sdase/commons/spring/boot/web/defaults.properties
@@ -1,6 +1,6 @@
 server.servlet.context-path=/api
 server.port=8080
-server.max-http-header-size=8192
+server.max-http-request-header-size=8192
 server.error.whitelabel.enabled=false
 
 server.tomcat.basedir=${java.io.tmpdir}/tomcat


### PR DESCRIPTION
…ith `server.max-http-request-header-size`

For details, see here: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#servermax-http-header-size