### PR TITLE
Add test support for external MongoDB

### DIFF
--- a/.github/workflows/mongodb.yml
+++ b/.github/workflows/mongodb.yml
@@ -25,7 +25,7 @@ jobs:
           cache: 'gradle'
 
       - name: Start MongoDB
-        run: docker run -d -e MONGO_INITDB_ROOT_USERNAME=test -e MONGO_INITDB_ROOT_PASSWORD=example -p 27017:27017 --name test_mongo mongo:4.4
+        run: docker run -d -e MONGO_INITDB_ROOT_USERNAME=test -e MONGO_INITDB_ROOT_PASSWORD=example -p 27017:27017 --name test_mongo mongo:5.0
 
       - name: Test with Gradle
         run: ./gradlew :sda-commons-starter-mongodb:test

--- a/.github/workflows/mongodb.yml
+++ b/.github/workflows/mongodb.yml
@@ -1,0 +1,38 @@
+# This workflow tests the feature of using an external MongoDB for tests
+name: Java Test MongoDB
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  # Test with real MongoDB
+  test-mongodb:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      TEST_MONGODB_CONNECTION_STRING: mongodb://test:example@localhost:27017/testdb?authSource=admin
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # v3.11.0
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'gradle'
+
+      - name: Start MongoDB
+        run: docker run -d -e MONGO_INITDB_ROOT_USERNAME=test -e MONGO_INITDB_ROOT_PASSWORD=example -p 27017:27017 --name test_mongo mongo:4.4
+
+      - name: Test with Gradle
+        run: ./gradlew :sda-commons-starter-mongodb:test
+
+      - name: Assert use of MongoDB
+        run: "docker logs test_mongo | grep -F 'createCollection' | grep -F 'testdb.'"
+
+      - name: Stop MongoDB
+        run: docker stop test_mongo
+

--- a/.github/workflows/mongodb.yml
+++ b/.github/workflows/mongodb.yml
@@ -25,7 +25,7 @@ jobs:
           cache: 'gradle'
 
       - name: Start MongoDB
-        run: docker run -d -e MONGO_INITDB_ROOT_USERNAME=test -e MONGO_INITDB_ROOT_PASSWORD=example -p 27017:27017 --name test_mongo mongo:5.0
+        run: docker run -d -e MONGO_INITDB_ROOT_USERNAME=test -e MONGO_INITDB_ROOT_PASSWORD=example -p 27017:27017 --name test_mongo mongo:5.0.20-focal
 
       - name: Test with Gradle
         run: ./gradlew :sda-commons-starter-mongodb:test

--- a/docs/starter-mongodb.md
+++ b/docs/starter-mongodb.md
@@ -40,3 +40,40 @@ used by the mongodb client.
 All certificates found in subdirectories will also be loaded.
 
 Note that this directory is also configurable through the property `sda.caCertificates.certificatesDir`.
+
+
+## Testing
+
+It is recommended to test with an embedded MongoDB using Flapdoodle's Spring Boot module and the
+SDA Spring Boot Commons testing module:
+
+```groovy
+dependencies {
+  testImplementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo.spring30x'
+  testImplementation 'org.sdase.commons.spring.boot:sda-commons-web-testing'
+}
+```
+
+Flapdoodle will start a MongoDB server and configures the connection for Spring Boot tests.
+The MongoDB version can be selected with (test) application properties:
+
+```properties
+de.flapdoodle.mongodb.embedded.version=4.4.1
+```
+
+`MongoOperations` can be used to clean the database between tests:
+
+```java
+  @Autowired MongoOperations mongoOperations;
+
+  @BeforeEach
+  void beforeEach() {
+    mongoOperations.dropCollection("collectionUnderTest");
+  }
+```
+
+To skip Flapdoodle's autoconfiguration and use a provided database (e.g. an AWS DocumentDB), the
+property `test.mongodb.connection.string` (or environment variable `TEST_MONGODB_CONNECTION_STRING`)
+can be used to provide a complete [MongoDB Connection String](https://docs.mongodb.com/manual/reference/connection-string/).
+This feature is provided by the SDA Spring Boot Commons testing module and is only activated when
+Flapdoodle's autoconfiguration is available for the test setup.

--- a/sda-commons-starter-mongodb/src/test/java/org/sdase/commons/spring/boot/ExternalMongoAutoConfigurationWithFlapdoodleTest.java
+++ b/sda-commons-starter-mongodb/src/test/java/org/sdase/commons/spring/boot/ExternalMongoAutoConfigurationWithFlapdoodleTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022- SDA SE Open Industry Solutions (https://www.sda.se)
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package org.sdase.commons.spring.boot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.sdase.commons.spring.boot.web.testing.mongodb.ExternalMongoAutoConfiguration;
+import org.springframework.mock.env.MockEnvironment;
+
+class ExternalMongoAutoConfigurationWithFlapdoodleTest {
+
+  ExternalMongoAutoConfiguration externalMongoAutoConfiguration =
+      new ExternalMongoAutoConfiguration();
+
+  @Test
+  void shouldExcludeFlapDoodleIfPropertyIsSet() {
+    var mockEnvironment =
+        new MockEnvironment().withProperty("test.mongodb.connection.string", "mongodb://localhost");
+    externalMongoAutoConfiguration.postProcessEnvironment(mockEnvironment, null);
+    assertThat(mockEnvironment.getProperty("spring.autoconfigure.exclude"))
+        .isEqualTo("de.flapdoodle.embed.mongo.spring.autoconfigure.EmbeddedMongoAutoConfiguration");
+  }
+
+  @Test
+  void shouldKeepExistingExcludesIfPropertyIsSet() {
+    var mockEnvironment =
+        new MockEnvironment()
+            .withProperty("test.mongodb.connection.string", "mongodb://localhost")
+            .withProperty("spring.autoconfigure.exclude", "com.example.ToBeExcluded");
+    externalMongoAutoConfiguration.postProcessEnvironment(mockEnvironment, null);
+    assertThat(mockEnvironment.getProperty("spring.autoconfigure.exclude"))
+        .isEqualTo(
+            "com.example.ToBeExcluded,de.flapdoodle.embed.mongo.spring.autoconfigure.EmbeddedMongoAutoConfiguration");
+  }
+
+  @Test
+  void shouldSetSpringDataMongoUri() {
+    var mockEnvironment =
+        new MockEnvironment().withProperty("test.mongodb.connection.string", "mongodb://localhost");
+    externalMongoAutoConfiguration.postProcessEnvironment(mockEnvironment, null);
+    assertThat(mockEnvironment.getProperty("spring.data.mongodb.uri"))
+        .isEqualTo("mongodb://localhost");
+  }
+
+  @Test
+  void shouldNotChangeEnvironmentWithoutProperty() {
+    var mockEnvironment =
+        new MockEnvironment()
+            .withProperty("spring.autoconfigure.exclude", "com.example.ToBeExcluded");
+    externalMongoAutoConfiguration.postProcessEnvironment(mockEnvironment, null);
+    assertThat(mockEnvironment.getProperty("spring.data.mongodb.uri")).isNull();
+    assertThat(mockEnvironment.getProperty("spring.autoconfigure.exclude"))
+        .isEqualTo("com.example.ToBeExcluded");
+  }
+}

--- a/sda-commons-web-testing/src/main/java/org/sdase/commons/spring/boot/web/testing/mongodb/ExternalMongoAutoConfiguration.java
+++ b/sda-commons-web-testing/src/main/java/org/sdase/commons/spring/boot/web/testing/mongodb/ExternalMongoAutoConfiguration.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022- SDA SE Open Industry Solutions (https://www.sda.se)
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package org.sdase.commons.spring.boot.web.testing.mongodb;
+
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+
+public class ExternalMongoAutoConfiguration implements EnvironmentPostProcessor {
+  private static final String FLAPDOODLE_AUTO_CONFIG_CLASS =
+      "de.flapdoodle.embed.mongo.spring.autoconfigure.EmbeddedMongoAutoConfiguration";
+  private static final String TEST_MONGODB_CONNECTION_STRING_PROPERTY_NAME =
+      "test.mongodb.connection.string";
+  private static final String AUTOCONFIGURE_EXCLUDES_PROPERTY_NAME = "spring.autoconfigure.exclude";
+  private static final String SPRING_DATA_MONGODB_URI_PROPERTY_NAME = "spring.data.mongodb.uri";
+
+  private static final Logger LOG = LoggerFactory.getLogger(ExternalMongoAutoConfiguration.class);
+
+  @Override
+  public void postProcessEnvironment(
+      ConfigurableEnvironment environment, SpringApplication application) {
+    String mongoDbUri = environment.getProperty(TEST_MONGODB_CONNECTION_STRING_PROPERTY_NAME);
+    if (mongoDbUri != null) {
+      try {
+        // fails if Flapdoodle embedded MongoDB is not available
+        getClass().getClassLoader().loadClass(FLAPDOODLE_AUTO_CONFIG_CLASS);
+        // not logging the value, it may contain credentials
+        LOG.info(
+            "Disabling {} and using MongoDB from {} for tests.",
+            FLAPDOODLE_AUTO_CONFIG_CLASS,
+            TEST_MONGODB_CONNECTION_STRING_PROPERTY_NAME);
+        excludeFlapdoodle(environment);
+        setTestMongoUri(environment, mongoDbUri);
+      } catch (ClassNotFoundException ignored) {
+        LOG.info(
+            "Not applying MongoDB defined with {}: "
+                + "Assuming no MongoDB tests because {} is not in the classpath.",
+            TEST_MONGODB_CONNECTION_STRING_PROPERTY_NAME,
+            FLAPDOODLE_AUTO_CONFIG_CLASS);
+      }
+    }
+  }
+
+  private static void excludeFlapdoodle(ConfigurableEnvironment environment) {
+    String excludes = environment.getProperty(AUTOCONFIGURE_EXCLUDES_PROPERTY_NAME);
+    if (StringUtils.isBlank(excludes)) {
+      excludes = FLAPDOODLE_AUTO_CONFIG_CLASS;
+    } else {
+      excludes = excludes + "," + FLAPDOODLE_AUTO_CONFIG_CLASS;
+    }
+    environment
+        .getPropertySources()
+        .addFirst(
+            new MapPropertySource(
+                "ExternalMongoEnvironmentPropertiesSource",
+                Map.of(AUTOCONFIGURE_EXCLUDES_PROPERTY_NAME, excludes)));
+  }
+
+  private static void setTestMongoUri(ConfigurableEnvironment environment, String mongoDbUri) {
+    environment
+        .getPropertySources()
+        .addFirst(
+            new MapPropertySource(
+                "ExternalMongoTestUriPropertiesSource",
+                Map.of(SPRING_DATA_MONGODB_URI_PROPERTY_NAME, mongoDbUri)));
+  }
+}

--- a/sda-commons-web-testing/src/main/resources/META-INF/spring.factories
+++ b/sda-commons-web-testing/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.env.EnvironmentPostProcessor=org.sdase.commons.spring.boot.web.testing.mongodb.ExternalMongoAutoConfiguration

--- a/sda-commons-web-testing/src/test/java/org/sdase/commons/spring/boot/web/testing/mongodb/ExternalMongoAutoConfigurationWithoutFlapdoodleTest.java
+++ b/sda-commons-web-testing/src/test/java/org/sdase/commons/spring/boot/web/testing/mongodb/ExternalMongoAutoConfigurationWithoutFlapdoodleTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022- SDA SE Open Industry Solutions (https://www.sda.se)
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package org.sdase.commons.spring.boot.web.testing.mongodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+class ExternalMongoAutoConfigurationWithoutFlapdoodleTest {
+
+  ExternalMongoAutoConfiguration externalMongoAutoConfiguration =
+      new ExternalMongoAutoConfiguration();
+
+  @Test
+  void shouldNotChangeEnvironmentWithoutProperty() {
+    var mockEnvironment =
+        new MockEnvironment()
+            .withProperty("spring.autoconfigure.exclude", "com.example.ToBeExcluded");
+    externalMongoAutoConfiguration.postProcessEnvironment(mockEnvironment, null);
+    assertThat(mockEnvironment.getProperty("spring.data.mongodb.uri")).isNull();
+    assertThat(mockEnvironment.getProperty("spring.autoconfigure.exclude"))
+        .isEqualTo("com.example.ToBeExcluded");
+  }
+
+  @Test
+  void shouldNotChangeEnvironmentWithProperty() {
+    var mockEnvironment =
+        new MockEnvironment()
+            .withProperty("test.mongodb.connection.string", "mongodb://localhost")
+            .withProperty("spring.autoconfigure.exclude", "com.example.ToBeExcluded");
+    externalMongoAutoConfiguration.postProcessEnvironment(mockEnvironment, null);
+    assertThat(mockEnvironment.getProperty("spring.data.mongodb.uri")).isNull();
+    assertThat(mockEnvironment.getProperty("spring.autoconfigure.exclude"))
+        .isEqualTo("com.example.ToBeExcluded");
+  }
+}


### PR DESCRIPTION
- [x] test in real service with real pipeline when snapshots are pushed to Nexus