### PR TITLE
 chore: align `testReport` with sda-dropwizard-commons

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -311,9 +311,11 @@ nexusStaging {
 
 // Reconfigure the testReport task to display the results of all modules into a single report
 task testReport(type: TestReport) {
-  destinationDirectory = file("$buildDir/reports/allTests")
+  destinationDirectory = project.layout.buildDirectory.dir("reports/allTests")
   // Include the results from the `test` task in all subprojects
-  testResults.from subprojects.findAll { !javaPlatformModules.contains(it.name) }*.test
+  testResults.from(
+      subprojects.findAll { !javaPlatformModules.contains(it.name) }*.test.binaryResultsDirectory
+      )
 }
 
 // Create a combined XML report of all modules in the root project


### PR DESCRIPTION
 * fixing deprecation of `buildDir`

Compare https://github.com/SDA-SE/sda-dropwizard-commons/pull/2728