### PR TITLE
chore: only enable dependency locking for java-library modules

### DIFF
--- a/.github/workflows/ignore-policy.rego
+++ b/.github/workflows/ignore-policy.rego
@@ -5,9 +5,7 @@ import data.lib.trivy
 default ignore = false
 
 ignore_cves := {
-  "CVE-2016-1000027", # org.springframework:spring-web:5.3.29
-  "CVE-2022-40159", # commons-jxpath:commons-jxpath:1.3: used by spotless-2116170985 (strange name, you can find it if you execute `./gradlew dependencies`), i.e. only build-time dependency
-  "CVE-2022-40160", # commons-jxpath:commons-jxpath:1.3
+  # "CVE-2016-1000027", # description
 }
 
 ignore {

--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,6 @@ group 'org.sdase.commons.spring.boot'
 allprojects {
   apply plugin: 'idea'
 
-  dependencyLocking { lockAllConfigurations() }
-
   // Task for creating gradle.lockfile per module. Needed for Trivy vulnerability scan.
   task resolveAndLockAll {
     doFirst {
@@ -190,6 +188,15 @@ subprojects {
 configure(subprojects.findAll { !javaPlatformModules.contains(it.name) }) {
   apply plugin: 'jacoco'
   apply plugin: 'java-library'
+
+  // activate dependency locking for most configurations
+  var ignoredConfigurationPatternsForDependencyLocking = Set.of("test.*")
+  configurations.matching { configuration ->
+    !ignoredConfigurationPatternsForDependencyLocking.any { configuration.name.matches(it) }
+  }.each {configuration ->
+    println "Activating dependency locking for '${it.name}:${configuration.name}'"
+    configuration.resolutionStrategy.activateDependencyLocking()
+  }
 
   sourceCompatibility = JavaVersion.VERSION_17
 


### PR DESCRIPTION
* dependency locking will now only be used for java-library modules
* test configurations will be ignored

Can replace #393