### PR TITLE
fix(deps): bump springBootVersion from 3.1.5 to 3.1.6

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -10,7 +10,7 @@ ext {
   awaitalityVersion = '4.2.0'
   bouncycastleVersion = '1.77'
   logbackContribVersion = '0.1.5'
-  springBootVersion = '3.1.5'
+  springBootVersion = '3.1.6'
   springCloudVersion = '2022.0.4'
   scalaVersion = '2.13.12'
   swaggerCoreVersion = '2.2.19'


### PR DESCRIPTION
Release Notes:
* https://github.com/spring-projects/spring-boot/releases/tag/v3.1.6

Fixes [CVE-2023-34055](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2023-34055)

Alternative to https://github.com/SDA-SE/sda-spring-boot-commons/pull/478 since we're still waiting for a release of Spring Cloud.