### PR TITLE
test: migrate to AWS SDK v2 + replace S3Mock

### DIFF
--- a/docs/starter-s3.md
+++ b/docs/starter-s3.md
@@ -15,3 +15,8 @@ The configuration class contains two beans, namely:
 The following properties are needed for the configuration.
 
 --8<-- "doc-snippets/config-starter-s3.md"
+
+## Testing
+
+We recommend to use [Robothy's local-s3](https://github.com/Robothy/local-s3) JUnit 5 extension
+for testing.

--- a/sda-commons-starter-s3/build.gradle
+++ b/sda-commons-starter-s3/build.gradle
@@ -3,12 +3,15 @@ dependencies {
   implementation "io.awspring.cloud:spring-cloud-aws-s3"
 
   testImplementation 'org.springframework.boot:spring-boot-starter-test'
-  testImplementation 'io.findify:s3mock_2.13:0.2.6', {
-    exclude group: 'com.google.guava', module: 'guava' // 21.0, CVE-2023-2976 + CVE-2018-10237
-    exclude group: 'commons-logging', module: 'commons-logging' // conflict
-    exclude group: 'com.amazonaws', module: 'aws-java-sdk-s3' // CVE-2022-31159
+  testImplementation 'io.github.robothy:local-s3-jupiter:1.13', {
+    exclude group: 'software.amazon.awssdk'
+    exclude group: 'com.amazonaws', module: 'aws-java-sdk'
+    exclude group: 'org.slf4j', module: 'slf4j-api'
   }
-  testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.633', {
-    exclude group: 'commons-logging', module: 'commons-logging' // conflict
+  testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.518', {
+    // only for pinning the version, don't use in code!
+    exclude group: 'commons-logging', module: 'commons-logging'
   }
+
+  testImplementation 'software.amazon.awssdk:s3' // use version defined in spring-cloud-aws-s3
 }

--- a/sda-commons-starter-s3/src/test/java/org/sdase/commons/spring/boot/s3/config/S3BucketRepositoryIntegrationTest.java
+++ b/sda-commons-starter-s3/src/test/java/org/sdase/commons/spring/boot/s3/config/S3BucketRepositoryIntegrationTest.java
@@ -10,76 +10,96 @@ package org.sdase.commons.spring.boot.s3.config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.AnonymousAWSCredentials;
-import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import com.amazonaws.services.s3.model.S3ObjectSummary;
-import io.findify.s3mock.S3Mock;
+import com.robothy.s3.jupiter.LocalS3;
+import com.robothy.s3.jupiter.LocalS3Endpoint;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.net.ServerSocket;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Object;
 
+@LocalS3
 class S3BucketRepositoryIntegrationTest {
 
-  static final String TEST_REGION = "eu-central-1";
+  private static final Logger LOG =
+      LoggerFactory.getLogger(S3BucketRepositoryIntegrationTest.class);
+
   static final String TEST_BUCKET = "test-bucket";
 
-  static S3Mock s3Mock;
-  static String endpoint;
-  static AmazonS3 testClient;
-
-  @BeforeAll
-  static void initS3Mock() {
-    int port = getFreePort();
-    s3Mock = new S3Mock.Builder().withInMemoryBackend().withPort(port).build();
-    s3Mock.start();
-    endpoint = "http://localhost:" + port;
-
-    testClient =
-        AmazonS3ClientBuilder.standard()
-            .withEndpointConfiguration(
-                new AwsClientBuilder.EndpointConfiguration(endpoint, TEST_REGION))
-            .withPathStyleAccessEnabled(true)
-            .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
+  private S3Client createS3ClientAndDeleteTestBucket(LocalS3Endpoint endpoint) {
+    var s3Client =
+        S3Client.builder()
+            .region(Region.of(endpoint.region()))
+            .endpointOverride(URI.create(endpoint.endpoint()))
+            .serviceConfiguration(
+                software.amazon.awssdk.services.s3.S3Configuration.builder()
+                    .pathStyleAccessEnabled(true)
+                    .build())
+            .credentialsProvider(AnonymousCredentialsProvider.create())
             .build();
+    deleteTestBucket(s3Client);
+    return s3Client;
   }
 
-  @AfterAll
-  static void afterAll() {
-    s3Mock.stop();
+  private void deleteTestBucket(S3Client s3Client) {
+    try {
+      deleteAllObjects(s3Client);
+      s3Client.deleteBucket(DeleteBucketRequest.builder().bucket(TEST_BUCKET).build());
+    } catch (NoSuchBucketException e) {
+      // ignore
+    }
   }
 
-  @AfterEach
-  void removeBucket() {
-    testClient.deleteBucket(TEST_BUCKET);
+  void deleteAllObjects(S3Client client) {
+    var response = client.listObjects(ListObjectsRequest.builder().bucket(TEST_BUCKET).build());
+    response.contents().stream()
+        .map(
+            s3Object ->
+                DeleteObjectRequest.builder().bucket(TEST_BUCKET).key(s3Object.key()).build())
+        .forEach(client::deleteObject);
+    if (!response.sdkHttpResponse().isSuccessful()) {
+      LOG.info("Could not delete objects in bucket: {}", TEST_BUCKET);
+    }
   }
 
   @Test
-  void shouldListObjects() {
-    createObjects(Map.of("file-1", "content-1", "file-2", "content-2"));
-    S3BucketRepository s3BucketRepository = createS3BucketRepository();
+  void shouldListObjects(LocalS3Endpoint endpoint) {
+    var s3Client = createS3ClientAndDeleteTestBucket(endpoint);
+    createObjects(s3Client, Map.of("file-1", "content-1", "file-2", "content-2"));
+    S3BucketRepository s3BucketRepository = createS3BucketRepository(endpoint);
 
     var actual = s3BucketRepository.listings();
     assertThat(actual).containsExactlyInAnyOrder("file-1", "file-2");
   }
 
   @Test
-  void shouldFindOutIfObjectExists() {
-    createObjects(Map.of("file-1", "content-1", "file-2", "content-2"));
-    S3BucketRepository s3BucketRepository = createS3BucketRepository();
+  void shouldFindOutIfObjectExists(LocalS3Endpoint endpoint) {
+    var s3Client = createS3ClientAndDeleteTestBucket(endpoint);
+    createObjects(s3Client, Map.of("file-1", "content-1", "file-2", "content-2"));
+    S3BucketRepository s3BucketRepository = createS3BucketRepository(endpoint);
 
     var actual =
         List.of(
@@ -91,121 +111,151 @@ class S3BucketRepositoryIntegrationTest {
   }
 
   @Test
-  void shouldDeleteFile() {
-    createObjects(Map.of("file-1", "content-1", "file-2", "content-2"));
-    S3BucketRepository s3BucketRepository = createS3BucketRepository();
+  void shouldDeleteFile(LocalS3Endpoint endpoint) {
+    var s3Client = createS3ClientAndDeleteTestBucket(endpoint);
+    createObjects(s3Client, Map.of("file-1", "content-1", "file-2", "content-2"));
+    S3BucketRepository s3BucketRepository = createS3BucketRepository(endpoint);
 
     s3BucketRepository.deleteFile("file-1");
 
-    assertThat(testClient.listObjects(TEST_BUCKET).getObjectSummaries())
-        .hasSize(1)
-        .extracting(S3ObjectSummary::getKey)
-        .containsExactly("file-2");
+    ListObjectsResponse response =
+        s3Client.listObjects(ListObjectsRequest.builder().bucket(TEST_BUCKET).build());
+    assertThat(response.contents()).hasSize(1).extracting(S3Object::key).containsExactly("file-2");
   }
 
   @Test
-  void shouldGetObject() {
-    createObjects(Map.of("file-1", "content-1"));
-    S3BucketRepository s3BucketRepository = createS3BucketRepository();
+  void shouldGetObject(LocalS3Endpoint endpoint) {
+    var s3Client = createS3ClientAndDeleteTestBucket(endpoint);
+    createObjects(s3Client, Map.of("file-1", "content-1"));
+    S3BucketRepository s3BucketRepository = createS3BucketRepository(endpoint);
 
     var actual = s3BucketRepository.findByName("file-1");
     assertThat(actual).asString().isEqualTo("content-1");
   }
 
   @Test
-  void shouldGetUtf8Object() {
-    createObjects(Map.of("file-1", "content-1 with ä"));
-    S3BucketRepository s3BucketRepository = createS3BucketRepository();
+  void shouldGetUtf8Object(LocalS3Endpoint endpoint) {
+    var s3Client = createS3ClientAndDeleteTestBucket(endpoint);
+    createObjects(s3Client, Map.of("file-1", "content-1 with ä"));
+    S3BucketRepository s3BucketRepository = createS3BucketRepository(endpoint);
 
     var actual = s3BucketRepository.findByName("file-1");
     assertThat(actual).contains("content-1 with ä".getBytes(StandardCharsets.UTF_8));
   }
 
   @Test
-  void shouldNotSaveNullContent() {
-    createObjects(Map.of());
-    S3BucketRepository s3BucketRepository = createS3BucketRepository();
+  void shouldNotSaveNullContent(LocalS3Endpoint endpoint) {
+    var s3Client = createS3ClientAndDeleteTestBucket(endpoint);
+    createObjects(s3Client, Map.of());
+    S3BucketRepository s3BucketRepository = createS3BucketRepository(endpoint);
 
     assertThatExceptionOfType(IOException.class)
         .isThrownBy(() -> s3BucketRepository.save("test-object", null));
   }
 
   @Test
-  void shouldSaveContent() throws IOException {
-    createObjects(Map.of());
+  void shouldSaveContent(LocalS3Endpoint endpoint) throws Exception {
+    var s3Client = createS3ClientAndDeleteTestBucket(endpoint);
+    createObjects(s3Client, Map.of());
     // precondition
-    assertThat(testClient.listObjects(TEST_BUCKET).getObjectSummaries()).isEmpty();
-    S3BucketRepository s3BucketRepository = createS3BucketRepository();
+    ListObjectsResponse response =
+        s3Client.listObjects(ListObjectsRequest.builder().bucket(TEST_BUCKET).build());
+    assertThat(response.contents()).isEmpty();
+    S3BucketRepository s3BucketRepository = createS3BucketRepository(endpoint);
 
     s3BucketRepository.save("test-object", "test-content");
 
-    assertThat(testClient.getObject(TEST_BUCKET, "test-object").getObjectContent())
-        .hasContent("test-content");
+    try (ResponseInputStream<GetObjectResponse> responseInputStream =
+        s3Client.getObject(
+            GetObjectRequest.builder().bucket(TEST_BUCKET).key("test-object").build())) {
+      assertThat(new String(responseInputStream.readAllBytes(), StandardCharsets.UTF_8))
+          .isEqualTo("test-content");
+    }
   }
 
   @Test
-  void shouldSaveUtf8Content() throws IOException {
-    createObjects(Map.of());
+  void shouldSaveUtf8Content(LocalS3Endpoint endpoint) throws IOException {
+    var s3Client = createS3ClientAndDeleteTestBucket(endpoint);
+    createObjects(s3Client, Map.of());
     // precondition
-    assertThat(testClient.listObjects(TEST_BUCKET).getObjectSummaries()).isEmpty();
-    S3BucketRepository s3BucketRepository = createS3BucketRepository();
+    ListObjectsResponse response =
+        s3Client.listObjects(ListObjectsRequest.builder().bucket(TEST_BUCKET).build());
+    assertThat(response.contents()).isEmpty();
+    S3BucketRepository s3BucketRepository = createS3BucketRepository(endpoint);
 
     s3BucketRepository.save("test-utf8-object", "test-content with ä");
 
-    assertThat(testClient.getObject(TEST_BUCKET, "test-utf8-object").getObjectContent())
-        .hasBinaryContent("test-content with ä".getBytes(StandardCharsets.UTF_8));
+    try (ResponseInputStream<GetObjectResponse> responseInputStream =
+        s3Client.getObject(
+            GetObjectRequest.builder().bucket(TEST_BUCKET).key("test-utf8-object").build())) {
+      assertThat(responseInputStream.readAllBytes())
+          .isEqualTo("test-content with ä".getBytes(StandardCharsets.UTF_8));
+    }
   }
 
   @Test
-  void shouldSaveUtf8File() throws IOException, URISyntaxException {
+  void shouldSaveUtf8File(LocalS3Endpoint endpoint) throws IOException, URISyntaxException {
+    var s3Client = createS3ClientAndDeleteTestBucket(endpoint);
     File testFile =
         new File(Objects.requireNonNull(getClass().getResource("/test-data/some-text.md")).toURI());
-    createObjects(Map.of());
+    createObjects(s3Client, Map.of());
     // precondition
-    assertThat(testClient.listObjects(TEST_BUCKET).getObjectSummaries()).isEmpty();
-    S3BucketRepository s3BucketRepository = createS3BucketRepository();
+    ListObjectsResponse response =
+        s3Client.listObjects(ListObjectsRequest.builder().bucket(TEST_BUCKET).build());
+    assertThat(response.contents()).isEmpty();
+    S3BucketRepository s3BucketRepository = createS3BucketRepository(endpoint);
 
     s3BucketRepository.saveFile("test-utf8-file", testFile);
 
-    assertThat(testClient.getObject(TEST_BUCKET, "test-utf8-file").getObjectContent())
-        .hasSameContentAs(new FileInputStream(testFile));
+    try (ResponseInputStream<GetObjectResponse> responseInputStream =
+        s3Client.getObject(
+            GetObjectRequest.builder().bucket(TEST_BUCKET).key("test-utf8-file").build())) {
+      assertThat(responseInputStream.readAllBytes())
+          .asString()
+          .isEqualTo(Files.readString(testFile.toPath(), StandardCharsets.UTF_8));
+    }
   }
 
   @Test
-  void shouldSaveBinaryFile() throws IOException, URISyntaxException {
+  void shouldSaveBinaryFile(LocalS3Endpoint endpoint) throws IOException, URISyntaxException {
+    var s3Client = createS3ClientAndDeleteTestBucket(endpoint);
     File testFile =
         new File(
             Objects.requireNonNull(getClass().getResource("/test-data/some-text.md.zip")).toURI());
-    createObjects(Map.of());
+    createObjects(s3Client, Map.of());
     // precondition
-    assertThat(testClient.listObjects(TEST_BUCKET).getObjectSummaries()).isEmpty();
-    S3BucketRepository s3BucketRepository = createS3BucketRepository();
+    ListObjectsResponse response =
+        s3Client.listObjects(ListObjectsRequest.builder().bucket(TEST_BUCKET).build());
+    assertThat(response.contents()).isEmpty();
+    S3BucketRepository s3BucketRepository = createS3BucketRepository(endpoint);
 
     s3BucketRepository.saveFile("test-binary-file", testFile);
 
-    assertThat(testClient.getObject(TEST_BUCKET, "test-binary-file").getObjectContent())
-        .hasSameContentAs(new FileInputStream(testFile));
+    try (ResponseInputStream<GetObjectResponse> responseInputStream =
+        s3Client.getObject(
+            GetObjectRequest.builder().bucket(TEST_BUCKET).key("test-binary-file").build())) {
+      assertThat(responseInputStream.readAllBytes())
+          .isEqualTo(Files.readAllBytes(testFile.toPath()));
+    }
   }
 
-  private static S3BucketRepository createS3BucketRepository() {
+  private S3BucketRepository createS3BucketRepository(LocalS3Endpoint endpoint) {
     S3Configuration s3Configuration =
-        new S3Configuration("", "", endpoint, TEST_REGION, TEST_BUCKET);
+        new S3Configuration("", "", endpoint.endpoint(), endpoint.region(), TEST_BUCKET);
     return s3Configuration.s3BucketRepository(s3Configuration.getAmazonS3Client());
   }
 
-  private void createObjects(Map<String, String> objectsByKey) {
-    if (!testClient.doesBucketExistV2(TEST_BUCKET)) {
-      testClient.createBucket(TEST_BUCKET);
+  private void createObjects(S3Client testClient, Map<String, String> objectsByKey) {
+    try {
+      testClient.headBucket(HeadBucketRequest.builder().bucket(TEST_BUCKET).build());
+    } catch (NoSuchBucketException e) {
+      testClient.createBucket(CreateBucketRequest.builder().bucket(TEST_BUCKET).build());
     }
-    objectsByKey.forEach((key, content) -> testClient.putObject(TEST_BUCKET, key, content));
-  }
 
-  private static int getFreePort() {
-    try (ServerSocket socket = new ServerSocket(0)) {
-      socket.setReuseAddress(true);
-      return socket.getLocalPort();
-    } catch (IOException e) {
-      throw new UncheckedIOException("Could not find a free port.", e);
-    }
+    objectsByKey.forEach(
+        (key, content) ->
+            testClient.putObject(
+                PutObjectRequest.builder().bucket(TEST_BUCKET).key(key).build(),
+                RequestBody.fromString(content)));
   }
 }


### PR DESCRIPTION
Disadvantages of local-s3:
* I'm not super happy, because the library does not provide an easy way to access S3 in a `before` or `after` method
* we don't get rid of com.amazonaws:aws-java-sdk-s3 completely because it's needed by local-s3

At least the first point would be solved if we'd provide our own extension [like in sda-dropwizard-commons](https://github.com/SDA-SE/sda-dropwizard-commons/blob/master/sda-commons-server-s3-testing/src/main/java/org/sdase/commons/server/s3/testing/S3ClassExtension.java). But sda-spring-boot-commons does not provide an s3-testing module ATM.

Edit:
I've create 2 issues to discuss my findings / concerns with the maintainer of the local-s3 repository:
* https://github.com/Robothy/local-s3/issues/80
* https://github.com/Robothy/local-s3/issues/81