### PR TITLE
fix: application should start without definition of `management.serve…

### DIFF
--- a/sda-commons-app-example/src/main/resources/application.properties
+++ b/sda-commons-app-example/src/main/resources/application.properties
@@ -1,3 +1,2 @@
 spring.application.name=spring-boot-commons-example
 server.port=8080
-management.server.port=8081

--- a/sda-commons-app-example/src/test/java/org/sdase/commons/spring/boot/web/app/example/ManagementAuthorizationManagerTest.java
+++ b/sda-commons-app-example/src/test/java/org/sdase/commons/spring/boot/web/app/example/ManagementAuthorizationManagerTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022- SDA SE Open Industry Solutions (https://www.sda.se)
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package org.sdase.commons.spring.boot.web.app.example;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import org.junit.jupiter.api.Test;
+import org.sdase.commons.spring.boot.web.auth.management.ManagementAuthorizationManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalManagementPort;
+
+@SpringBootTest(classes = App.class, webEnvironment = RANDOM_PORT)
+class ManagementAuthorizationManagerTest {
+
+  @Autowired private ManagementAuthorizationManager managementAccessDecisionVoter;
+
+  @LocalManagementPort private int managementPort;
+
+  @Test
+  void beanShouldBeAvailable() {
+    assertThat(managementAccessDecisionVoter).isNotNull();
+  }
+
+  @Test
+  void managementPortShouldBeSetToDefault() {
+    assertThat(managementPort).isEqualTo(8081);
+  }
+}

--- a/sda-commons-app-example/src/test/java/org/sdase/commons/spring/boot/web/app/example/ManagementAuthorizationManagerWithModifiedManagementPortTest.java
+++ b/sda-commons-app-example/src/test/java/org/sdase/commons/spring/boot/web/app/example/ManagementAuthorizationManagerWithModifiedManagementPortTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022- SDA SE Open Industry Solutions (https://www.sda.se)
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package org.sdase.commons.spring.boot.web.app.example;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import org.junit.jupiter.api.Test;
+import org.sdase.commons.spring.boot.web.auth.management.ManagementAuthorizationManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalManagementPort;
+
+@SpringBootTest(
+    classes = App.class,
+    webEnvironment = RANDOM_PORT,
+    properties = "management.server.port=8888")
+class ManagementAuthorizationManagerWithModifiedManagementPortTest {
+
+  @Autowired private ManagementAuthorizationManager managementAccessDecisionVoter;
+
+  @LocalManagementPort private int managementPort;
+
+  @Test
+  void beanShouldBeAvailable() {
+    assertThat(managementAccessDecisionVoter).isNotNull();
+  }
+
+  @Test
+  void managementPortShouldBeSetToDefault() {
+    assertThat(managementPort).isEqualTo(8888);
+  }
+}

--- a/sda-commons-starter-web/src/main/java/org/sdase/commons/spring/boot/web/auth/management/ManagementAuthorizationManager.java
+++ b/sda-commons-starter-web/src/main/java/org/sdase/commons/spring/boot/web/auth/management/ManagementAuthorizationManager.java
@@ -8,71 +8,56 @@
 package org.sdase.commons.spring.boot.web.auth.management;
 
 import java.util.function.Supplier;
-import org.springframework.boot.actuate.autoconfigure.web.server.ConditionalOnManagementPort;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
-import org.springframework.boot.web.servlet.context.ServletWebServerInitializedEvent;
-import org.springframework.context.event.EventListener;
+import org.springframework.core.env.Environment;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
 import org.springframework.stereotype.Component;
 
-public interface ManagementAuthorizationManager
-    extends AuthorizationManager<RequestAuthorizationContext> {
+@Component
+public class ManagementAuthorizationManager
+    implements AuthorizationManager<RequestAuthorizationContext> {
+
+  private final Integer managementServerPort;
+
+  private final Environment environment;
+
+  public ManagementAuthorizationManager(
+      Environment environment, @Value("${management.server.port}") Integer managementServerPort) {
+    this.environment = environment;
+    this.managementServerPort = managementServerPort;
+  }
 
   @Override
-  default void verify(Supplier<Authentication> authentication, RequestAuthorizationContext object) {
+  public void verify(Supplier<Authentication> authentication, RequestAuthorizationContext object) {
     AuthorizationManager.super.verify(authentication, object);
   }
 
-  @Component
-  @ConditionalOnManagementPort(ManagementPortType.DIFFERENT)
-  class DifferentPortManagementAccessDecisionVoter implements ManagementAuthorizationManager {
-
-    /**
-     * The management port discovered in {@link
-     * #onApplicationEvent(ServletWebServerInitializedEvent)}. Initially a value that can't be an
-     * existing port to avoid granting access by accident to the application API.
-     */
-    private int managementPort = -1;
-
-    @EventListener
-    public void onApplicationEvent(ServletWebServerInitializedEvent event) {
-      if ("management".equals(event.getApplicationContext().getServerNamespace())) {
-        this.managementPort = event.getWebServer().getPort();
-      }
-    }
-
-    @Override
-    public AuthorizationDecision check(
-        Supplier<Authentication> authentication, RequestAuthorizationContext object) {
-      int requestLocalPort = object.getRequest().getLocalPort();
-      return requestLocalPort == this.managementPort
-          ? new AuthorizationDecision(true)
-          : new AuthorizationDecision(false);
-    }
+  @Override
+  public AuthorizationDecision check(
+      Supplier<Authentication> authentication, RequestAuthorizationContext context) {
+    return switch (ManagementPortType.get(environment)) {
+      case SAME -> checkIfPortsAreSame();
+      case DIFFERENT -> checkIfPortsAreDifferent(context);
+      case DISABLED -> checkIfManagementServerPortIsDisabled();
+    };
   }
 
-  @Component
-  @ConditionalOnManagementPort(ManagementPortType.SAME)
-  class IgnoreSamePortManagementAccessDecisionVoter implements ManagementAuthorizationManager {
-
-    @Override
-    public AuthorizationDecision check(
-        Supplier<Authentication> authentication, RequestAuthorizationContext object) {
-      return new AuthorizationDecision(false);
-    }
+  private AuthorizationDecision checkIfPortsAreDifferent(RequestAuthorizationContext context) {
+    int requestLocalPort = context.getRequest().getLocalPort();
+    return requestLocalPort == this.managementServerPort
+        ? new AuthorizationDecision(true)
+        : new AuthorizationDecision(false);
   }
 
-  @Component
-  @ConditionalOnManagementPort(ManagementPortType.DISABLED)
-  class DisabledManagementAccessDecisionVoter implements ManagementAuthorizationManager {
+  private AuthorizationDecision checkIfManagementServerPortIsDisabled() {
+    return new AuthorizationDecision(false);
+  }
 
-    @Override
-    public AuthorizationDecision check(
-        Supplier<Authentication> authentication, RequestAuthorizationContext object) {
-      return new AuthorizationDecision(false);
-    }
+  private AuthorizationDecision checkIfPortsAreSame() {
+    return new AuthorizationDecision(false);
   }
 }

--- a/sda-commons-starter-web/src/test/java/org/sdase/commons/spring/boot/web/auth/management/ManagementAuthorizationManagerCoverageTest.java
+++ b/sda-commons-starter-web/src/test/java/org/sdase/commons/spring/boot/web/auth/management/ManagementAuthorizationManagerCoverageTest.java
@@ -21,9 +21,8 @@ class ManagementAuthorizationManagerCoverageTest {
   @Test
   void shouldNotDecideOnSamePort() {
     assertThat(createTestContext(ActuatorSamePortApp.class))
-        .hasSingleBean(
-            ManagementAuthorizationManager.IgnoreSamePortManagementAccessDecisionVoter.class)
-        .getBean(ManagementAuthorizationManager.IgnoreSamePortManagementAccessDecisionVoter.class)
+        .hasSingleBean(ManagementAuthorizationManager.class)
+        .getBean(ManagementAuthorizationManager.class)
         .returns(
             new AuthorizationDecision(false).isGranted(), dv -> dv.check(null, null).isGranted());
   }
@@ -31,8 +30,8 @@ class ManagementAuthorizationManagerCoverageTest {
   @Test
   void shouldNotDecideOnDisabledPort() {
     assertThat(createTestContext(ActuatorDisabledPortApp.class))
-        .hasSingleBean(ManagementAuthorizationManager.DisabledManagementAccessDecisionVoter.class)
-        .getBean(ManagementAuthorizationManager.DisabledManagementAccessDecisionVoter.class)
+        .hasSingleBean(ManagementAuthorizationManager.class)
+        .getBean(ManagementAuthorizationManager.class)
         .returns(
             new AuthorizationDecision(false).isGranted(), dv -> dv.check(null, null).isGranted());
   }


### PR DESCRIPTION
…r.port`

We first need a discussion about our auto configuration approach. My feeling (I will write down some arguments) is that we should not use it to bootstrap our application.