### PR TITLE
fix: application should start without definition of `management.serve…

### DIFF
--- a/sda-commons-app-example/src/main/resources/application.properties
+++ b/sda-commons-app-example/src/main/resources/application.properties
@@ -1,3 +1,2 @@
 spring.application.name=spring-boot-commons-example
 server.port=8080
-management.server.port=8081

--- a/sda-commons-app-example/src/test/java/org/sdase/commons/spring/boot/web/app/example/ExampleAppTest.java
+++ b/sda-commons-app-example/src/test/java/org/sdase/commons/spring/boot/web/app/example/ExampleAppTest.java
@@ -19,9 +19,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @ContextConfiguration(initializers = {EnableSdaAuthMockInitializer.class})
 class ExampleAppTest {
   @LocalServerPort private int port;

--- a/sda-commons-app-example/src/test/java/org/sdase/commons/spring/boot/web/app/example/ManagementAuthorizationManagerTest.java
+++ b/sda-commons-app-example/src/test/java/org/sdase/commons/spring/boot/web/app/example/ManagementAuthorizationManagerTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022- SDA SE Open Industry Solutions (https://www.sda.se)
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package org.sdase.commons.spring.boot.web.app.example;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import org.junit.jupiter.api.Test;
+import org.sdase.commons.spring.boot.web.auth.management.ManagementAuthorizationManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalManagementPort;
+import org.springframework.test.annotation.DirtiesContext;
+
+@SpringBootTest(classes = App.class, webEnvironment = RANDOM_PORT)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class ManagementAuthorizationManagerTest {
+
+  @Autowired private ManagementAuthorizationManager managementAccessDecisionVoter;
+
+  @LocalManagementPort private int managementPort;
+
+  @Test
+  void beanShouldBeAvailable() {
+    assertThat(managementAccessDecisionVoter).isNotNull();
+  }
+
+  @Test
+  void managementPortShouldBeSetToDefault() {
+    assertThat(managementPort).isEqualTo(8081);
+  }
+}

--- a/sda-commons-app-example/src/test/java/org/sdase/commons/spring/boot/web/app/example/ManagementAuthorizationManagerWithModifiedManagementPortTest.java
+++ b/sda-commons-app-example/src/test/java/org/sdase/commons/spring/boot/web/app/example/ManagementAuthorizationManagerWithModifiedManagementPortTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022- SDA SE Open Industry Solutions (https://www.sda.se)
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package org.sdase.commons.spring.boot.web.app.example;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import org.junit.jupiter.api.Test;
+import org.sdase.commons.spring.boot.web.auth.management.ManagementAuthorizationManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalManagementPort;
+import org.springframework.test.annotation.DirtiesContext;
+
+@SpringBootTest(
+    classes = App.class,
+    webEnvironment = RANDOM_PORT,
+    properties = "management.server.port=8888")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class ManagementAuthorizationManagerWithModifiedManagementPortTest {
+
+  @Autowired private ManagementAuthorizationManager managementAccessDecisionVoter;
+
+  @LocalManagementPort private int managementPort;
+
+  @Test
+  void beanShouldBeAvailable() {
+    assertThat(managementAccessDecisionVoter).isNotNull();
+  }
+
+  @Test
+  void managementPortShouldBeSetToDefault() {
+    assertThat(managementPort).isEqualTo(8888);
+  }
+}

--- a/sda-commons-app-example/src/test/java/org/sdase/commons/spring/boot/web/app/example/OpenApiDocumentationTest.java
+++ b/sda-commons-app-example/src/test/java/org/sdase/commons/spring/boot/web/app/example/OpenApiDocumentationTest.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -36,6 +37,7 @@ import org.springframework.test.context.ContextConfiguration;
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = {"springdoc.packagesToScan=org.sdase.commons.spring.boot.web.app.example"})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @ContextConfiguration(initializers = DisableSdaAuthInitializer.class)
 class OpenApiDocumentationTest {
 

--- a/sda-commons-starter-web/src/main/java/org/sdase/commons/spring/boot/web/auth/SdaSecurityConfiguration.java
+++ b/sda-commons-starter-web/src/main/java/org/sdase/commons/spring/boot/web/auth/SdaSecurityConfiguration.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
+import org.sdase.commons.spring.boot.web.monitoring.SdaMonitoringConfiguration;
 import org.sdase.commons.spring.boot.web.security.headers.SdaSecurityHeaders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,7 +34,7 @@ import org.springframework.security.web.header.writers.StaticHeadersWriter;
 import org.springframework.util.StringUtils;
 
 @EnableWebSecurity
-@AutoConfiguration
+@AutoConfiguration(after = SdaMonitoringConfiguration.class)
 @ComponentScan
 @Order(1)
 public class SdaSecurityConfiguration {


### PR DESCRIPTION
…r.port`

Better alternative to #555 