### PR TITLE
fix: make aws-sdk libs available for the services

### DIFF
--- a/sda-commons-starter-s3/build.gradle
+++ b/sda-commons-starter-s3/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
   implementation "org.springframework.boot:spring-boot-autoconfigure"
-  implementation "io.awspring.cloud:spring-cloud-aws-s3"
+  api "io.awspring.cloud:spring-cloud-aws-s3"
 
   testImplementation 'org.springframework.boot:spring-boot-starter-test'
   testImplementation 'io.github.robothy:local-s3-jupiter:1.14', {


### PR DESCRIPTION
Usually if you want to extend the current `S3Repository` you need to again add the dependency to the service, which is not the case with other modules in sda-commons