### PR TITLE
add JUnit extension for a local S3 mock working with Spring Boot and sda-commons-starter-s3

### DIFF
--- a/docs/web-testing.md
+++ b/docs/web-testing.md
@@ -154,3 +154,26 @@ The version is managed by the library as described [above](#dependencies).
     ```java
     --8<-- "sda-commons-starter-kafka/src/test/java/org/sdase/commons/spring/boot/kafka/KafkaProducerIntegrationTest.java:12"
     ```
+
+
+## S3
+
+`sda-commons-web-testing` provides the annotation `S3Test` to start a local S3 mock with
+[Robothy local-s3](https://github.com/Robothy/local-s3) and configure Spring Boot as needed for
+`sda-commons-starter-s3`.
+`@S3Test` must be placed before `@SpringBootTest` if used for a full integration test with an
+application context.
+The dependency `io.github.robothy:local-s3-rest` must be added as test dependency to the project.
+`software.amazon.awssdk:s3` is needed as well and comes with `io.awspring.cloud:spring-cloud-aws-s3`
+via `sda-commons-starter-s3`.
+The versions are managed by the library as described [above](#dependencies).
+
+??? example "Test S3 Clients in Spring Boot Application"
+    ```java
+    --8<-- "sda-commons-app-example/src/test/java/org/sdase/commons/spring/boot/web/app/example/S3FileRepositoryIntegrationTest.java:12"
+    ```
+
+!!! info "Test S3 Clients without Spring Context"
+    `S3Test` can also be used in tests without a Spring Context.
+    Test, set up and tear down methods can request `S3Client` and `LocalS3Configuration` as
+    method parameter to interact with the S3 mock or set up the tested services.

--- a/sda-commons-app-example/build.gradle
+++ b/sda-commons-app-example/build.gradle
@@ -11,11 +11,13 @@ repositories {
 dependencies {
   implementation project(':sda-commons-starter-web')
   implementation project(':sda-commons-starter-mongodb')
+  implementation project(':sda-commons-starter-s3')
 
   testImplementation project(':sda-commons-web-testing')
   testImplementation project(':sda-commons-starter-kafka')
 
   testImplementation 'org.springframework.kafka:spring-kafka-test'
+  testImplementation 'io.github.robothy:local-s3-rest'
 }
 
 test {

--- a/sda-commons-app-example/src/main/java/org/sdase/commons/spring/boot/web/app/example/S3FileRepository.java
+++ b/sda-commons-app-example/src/main/java/org/sdase/commons/spring/boot/web/app/example/S3FileRepository.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022- SDA SE Open Industry Solutions (https://www.sda.se)
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package org.sdase.commons.spring.boot.web.app.example;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import org.sdase.commons.spring.boot.s3.config.S3BucketRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+public class S3FileRepository {
+
+  private final S3BucketRepository s3Repository;
+
+  public S3FileRepository(S3BucketRepository s3Repository) {
+    this.s3Repository = s3Repository;
+  }
+
+  public void uploadTextFile(String key, String text) {
+    try {
+      s3Repository.save(key, text);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  public String downloadText(String key) {
+    return new String(s3Repository.findByName(key), StandardCharsets.UTF_8);
+  }
+}

--- a/sda-commons-app-example/src/test/java/org/sdase/commons/spring/boot/web/app/example/S3FileRepositoryIntegrationTest.java
+++ b/sda-commons-app-example/src/test/java/org/sdase/commons/spring/boot/web/app/example/S3FileRepositoryIntegrationTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022- SDA SE Open Industry Solutions (https://www.sda.se)
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package org.sdase.commons.spring.boot.web.app.example;
+
+// ATTENTION: The source of this class is included in the public documentation.
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.INPUT_STREAM;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.sdase.commons.spring.boot.web.testing.s3.LocalS3Configuration;
+import org.sdase.commons.spring.boot.web.testing.s3.S3Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+@S3Test
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = {"management.server.port=0"})
+class S3FileRepositoryIntegrationTest {
+
+  @Autowired S3FileRepository s3FileRepository;
+
+  @Test
+  void shouldUploadTextFile(S3Client s3Client, LocalS3Configuration config) {
+    var givenKey = "test-file.txt";
+    var givenText = "Hello World!";
+
+    s3FileRepository.uploadTextFile(givenKey, givenText);
+
+    var actualContent = s3Client.listObjects(l -> l.bucket(config.bucketName()));
+    assertThat(actualContent.contents())
+        .hasSize(1)
+        .first()
+        .extracting(S3Object::key)
+        .isEqualTo("test-file.txt")
+        .extracting(k -> s3Client.getObject(o -> o.bucket(config.bucketName()).key(k)))
+        .asInstanceOf(INPUT_STREAM)
+        .hasContent("Hello World!");
+  }
+
+  @Test
+  void shouldDownloadTextFile(S3Client s3Client, LocalS3Configuration config) {
+    var givenKey = "existing-test-file.txt";
+    var givenText = "Hello World!";
+    s3Client.putObject(
+        o -> o.bucket(config.bucketName()).key(givenKey),
+        RequestBody.fromBytes(givenText.getBytes(StandardCharsets.UTF_8)));
+
+    String actualText = s3FileRepository.downloadText(givenKey);
+
+    assertThat(actualText).isEqualTo("Hello World!");
+  }
+}

--- a/sda-commons-app-example/src/test/resources/application.properties
+++ b/sda-commons-app-example/src/test/resources/application.properties
@@ -1,1 +1,7 @@
 app.kafka.producer.topic=test-topic-producer
+
+s3.accessKey=dummy
+s3.secretKey=dummy
+s3.endpoint=http://localhost:1234
+s3.region=local
+s3.bucketName=dummy

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -35,6 +35,9 @@ dependencies {
     api 'org.apache.httpcomponents:httpclient:4.5.14', {
       because 'conflict spring cloud (4.5.4 via maven resolver) and spring-cloud-aws-s3 (4.5.13 via awssdk)'
     }
+    api 'commons-io:commons-io:2.13.0', {
+      because 'conflict robothy, spring cloud, zookeeper'
+    }
 
     // sda-commons-starter-web
     api "org.bouncycastle:bcpkix-jdk18on:${bouncycastleVersion}", {
@@ -76,6 +79,7 @@ dependencies {
 
     // sda-commons-starter-s3
     api "io.awspring.cloud:spring-cloud-aws-s3:3.1.1"
+    api "io.github.robothy:local-s3-rest:1.14"
 
   }
 }

--- a/sda-commons-starter-s3/build.gradle
+++ b/sda-commons-starter-s3/build.gradle
@@ -3,15 +3,6 @@ dependencies {
   api "io.awspring.cloud:spring-cloud-aws-s3"
 
   testImplementation 'org.springframework.boot:spring-boot-starter-test'
-  testImplementation 'io.github.robothy:local-s3-jupiter:1.14', {
-    exclude group: 'software.amazon.awssdk'
-    exclude group: 'com.amazonaws', module: 'aws-java-sdk'
-    exclude group: 'org.slf4j', module: 'slf4j-api'
-  }
-  testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.688', {
-    // only for pinning the version, don't use in code!
-    exclude group: 'commons-logging', module: 'commons-logging'
-  }
-
-  testImplementation 'software.amazon.awssdk:s3' // use version defined in spring-cloud-aws-s3
+  testImplementation project(':sda-commons-web-testing')
+  testImplementation 'io.github.robothy:local-s3-rest'
 }

--- a/sda-commons-web-testing/build.gradle
+++ b/sda-commons-web-testing/build.gradle
@@ -14,5 +14,12 @@ dependencies {
   implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
   implementation 'com.nimbusds:nimbus-jose-jwt'
 
+  // Do not add the compileOnly dependencies as test dependencies to avoid passing tests that will
+  // not work for consumers!
+  compileOnly 'io.github.robothy:local-s3-rest'
+  // spring-cloud-aws-s3 manages and provides required software.amazon.awssdk:s3
+  // spring-cloud-aws-s3 is part of the api of sda-commons-starter-s3
+  compileOnly 'io.awspring.cloud:spring-cloud-aws-s3'
+
   testImplementation 'org.springframework.boot:spring-boot-actuator-autoconfigure'
 }

--- a/sda-commons-web-testing/src/main/java/org/sdase/commons/spring/boot/web/testing/s3/LocalS3Configuration.java
+++ b/sda-commons-web-testing/src/main/java/org/sdase/commons/spring/boot/web/testing/s3/LocalS3Configuration.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022- SDA SE Open Industry Solutions (https://www.sda.se)
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package org.sdase.commons.spring.boot.web.testing.s3;
+
+/**
+ * Provides all configuration information for a local S3 mock started via {@link S3Test} in tests.
+ * {@code LocalS3Configuration} can be used in test methods as well as {@link
+ * org.junit.jupiter.api.BeforeEach}, {@link org.junit.jupiter.api.BeforeAll}, {@link
+ * org.junit.jupiter.api.AfterEach} and {@link org.junit.jupiter.api.AfterAll} methods as parameter
+ * to get the current configuration for the test.
+ *
+ * @param accessKey the access key for the S3 connection, effectively any access key would work with
+ *     the S3 mock
+ * @param secretKey the secret key matching the {@code accessKey} for the S3 connection, effectively
+ *     any secret key would work with the S3 mock
+ * @param endpoint the endpoint in the form {@code http://localhost:<port>}, note that {@link
+ *     software.amazon.awssdk.services.s3.S3BaseClientBuilder#forcePathStyle(Boolean)} must be
+ *     {@code true}, otherwise, the client will use the bucket name as subdomain which can't be
+ *     resolved locally
+ * @param region the simulated AWS region of the local S3
+ * @param bucketName the {@linkplain S3Test#bucketName() configured bucket name}
+ */
+public record LocalS3Configuration(
+    String accessKey, String secretKey, String endpoint, String region, String bucketName) {}

--- a/sda-commons-web-testing/src/main/java/org/sdase/commons/spring/boot/web/testing/s3/LocalS3Extension.java
+++ b/sda-commons-web-testing/src/main/java/org/sdase/commons/spring/boot/web/testing/s3/LocalS3Extension.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2022- SDA SE Open Industry Solutions (https://www.sda.se)
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package org.sdase.commons.spring.boot.web.testing.s3;
+
+import com.robothy.s3.rest.LocalS3;
+import com.robothy.s3.rest.bootstrap.LocalS3Mode;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.endpoints.S3EndpointProvider;
+
+/**
+ * @see S3Test
+ */
+public class LocalS3Extension
+    implements BeforeAllCallback, BeforeEachCallback, AfterAllCallback, ParameterResolver {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LocalS3Extension.class);
+
+  private static final String S3_CLIENT_CLASS_NAME = "software.amazon.awssdk.services.s3.S3Client";
+  private static final String ROBOTHY_S3_SERVER_CLASS_NAME = "com.robothy.s3.rest.LocalS3";
+  private static final String LOCAL_CONFIGURATION_CLASS_NAME =
+      "org.sdase.commons.spring.boot.web.testing.s3.LocalS3Configuration";
+  private static final String REGION = "local";
+
+  private S3Test s3Test;
+  private String accessKeyBefore;
+  private String secretKeyBefore;
+  private String endpointBefore;
+  private String regionBefore;
+  private String bucketNameBefore;
+  private final List<AutoCloseable> closeOnFinish = new ArrayList<>();
+
+  @Override
+  public void beforeAll(ExtensionContext context) {
+    verifyDependency();
+
+    s3Test = context.getRequiredTestClass().getAnnotation(S3Test.class);
+    S3Test.S3 properties = s3Test.configurationProperties();
+
+    LocalS3 server = start();
+    closeOnFinish.add(server::shutdown);
+
+    accessKeyBefore = systemProperty(properties.accessKeyProperty(), UUID.randomUUID().toString());
+    secretKeyBefore = systemProperty(properties.secretKeyProperty(), UUID.randomUUID().toString());
+    endpointBefore =
+        systemProperty(
+            properties.endpointProperty(), "http://localhost:%d".formatted(server.getPort()));
+    regionBefore = systemProperty(properties.regionProperty(), REGION);
+    bucketNameBefore = systemProperty(properties.bucketNameProperty(), s3Test.bucketName());
+    //noinspection resource
+    createClient().createBucket(b -> b.bucket(s3Test.bucketName()));
+  }
+
+  @Override
+  public void afterAll(ExtensionContext context) {
+    verifyDependency();
+    closeOnFinish.forEach(
+        closeable -> {
+          try {
+            closeable.close();
+          } catch (Exception e) {
+            LOG.warn("Could not close {}", closeable, e);
+          }
+        });
+    systemProperty(s3Test.configurationProperties().accessKeyProperty(), accessKeyBefore);
+    systemProperty(s3Test.configurationProperties().secretKeyProperty(), secretKeyBefore);
+    systemProperty(s3Test.configurationProperties().endpointProperty(), endpointBefore);
+    systemProperty(s3Test.configurationProperties().regionProperty(), regionBefore);
+    systemProperty(s3Test.configurationProperties().bucketNameProperty(), bucketNameBefore);
+  }
+
+  @Override
+  public void beforeEach(ExtensionContext context) {
+    verifyDependency();
+    if (s3Test.cleanBeforeEach()) {
+      @SuppressWarnings("resource")
+      S3Client client = createClient();
+      client
+          .listObjects(l -> l.bucket(s3Test.bucketName()))
+          .contents()
+          .forEach(o -> client.deleteObject(d -> d.bucket(s3Test.bucketName()).key(o.key())));
+    }
+  }
+
+  private LocalS3 start() {
+    try {
+      LocalS3 localS3 = LocalS3.builder().port(-1).mode(LocalS3Mode.IN_MEMORY).build();
+      localS3.start();
+      return localS3;
+    } catch (RuntimeException e) {
+      throw new IllegalStateException("Failed to start Local S3.", e);
+    }
+  }
+
+  @Override
+  public boolean supportsParameter(
+      ParameterContext parameterContext, ExtensionContext extensionContext)
+      throws ParameterResolutionException {
+    verifyDependency();
+    String expectedClass = parameterContext.getParameter().getType().getName();
+    return S3_CLIENT_CLASS_NAME.equals(expectedClass)
+        || LOCAL_CONFIGURATION_CLASS_NAME.equals(expectedClass);
+  }
+
+  @Override
+  public Object resolveParameter(
+      ParameterContext parameterContext, ExtensionContext extensionContext)
+      throws ParameterResolutionException {
+    verifyDependency();
+    String expectedClass = parameterContext.getParameter().getType().getName();
+    return switch (expectedClass) {
+      case S3_CLIENT_CLASS_NAME -> createClient();
+      case LOCAL_CONFIGURATION_CLASS_NAME -> new LocalS3Configuration(
+          System.getProperty(s3Test.configurationProperties().accessKeyProperty()),
+          System.getProperty(s3Test.configurationProperties().secretKeyProperty()),
+          System.getProperty(s3Test.configurationProperties().endpointProperty()),
+          System.getProperty(s3Test.configurationProperties().regionProperty()),
+          System.getProperty(s3Test.configurationProperties().bucketNameProperty()));
+      default -> throw new IllegalArgumentException(
+          "Can't resolve parameter of type %s".formatted(expectedClass));
+    };
+  }
+
+  private S3Client createClient() {
+    S3Client client =
+        S3Client.builder()
+            .forcePathStyle(true)
+            .region(
+                Region.of(System.getProperty(s3Test.configurationProperties().regionProperty())))
+            .credentialsProvider(
+                StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(
+                        System.getProperty(s3Test.configurationProperties().accessKeyProperty()),
+                        System.getProperty(s3Test.configurationProperties().secretKeyProperty()))))
+            .endpointProvider(S3EndpointProvider.defaultProvider())
+            .endpointOverride(
+                URI.create(System.getProperty(s3Test.configurationProperties().endpointProperty())))
+            .build();
+    closeOnFinish.add(client);
+    return client;
+  }
+
+  private String systemProperty(String propertyName, String propertyValue) {
+    String previous = System.getProperty(propertyName);
+    if (propertyValue == null) {
+      System.clearProperty(propertyName);
+    } else {
+      System.setProperty(propertyName, propertyValue);
+    }
+    return previous;
+  }
+
+  private void verifyDependency() {
+    try {
+      getClass().getClassLoader().loadClass(ROBOTHY_S3_SERVER_CLASS_NAME);
+    } catch (ClassNotFoundException e) {
+      throw new IllegalStateException(
+          "Missing dependency. 'io.github.robothy:local-s3-rest' must be added to test dependencies.",
+          e);
+    }
+    try {
+      getClass().getClassLoader().loadClass(S3_CLIENT_CLASS_NAME);
+    } catch (ClassNotFoundException e) {
+      throw new IllegalStateException(
+          "Missing dependency. 'software.amazon.awssdk:s3' must be available in test dependencies.",
+          e);
+    }
+  }
+}

--- a/sda-commons-web-testing/src/main/java/org/sdase/commons/spring/boot/web/testing/s3/S3Test.java
+++ b/sda-commons-web-testing/src/main/java/org/sdase/commons/spring/boot/web/testing/s3/S3Test.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022- SDA SE Open Industry Solutions (https://www.sda.se)
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package org.sdase.commons.spring.boot.web.testing.s3;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Activates {@link LocalS3Extension}, starts a local S3 mock and provides {@link
+ * software.amazon.awssdk.services.s3.S3Client} and {@link LocalS3Configuration} for injection in
+ * test methods. For {@link org.springframework.boot.test.context.SpringBootTest}s, {@code S3Test}
+ * must be defined before {@link org.springframework.boot.test.context.SpringBootTest} and sets
+ * {@linkplain System#setProperty(String, String) system properties} as defined in {@link
+ * S3Test#configurationProperties()} to be picked up by Spring Boot.
+ *
+ * <p>{@link LocalS3Configuration} and {@link software.amazon.awssdk.services.s3.S3Client} can be
+ * used in test methods as well as {@link org.junit.jupiter.api.BeforeEach}, {@link
+ * org.junit.jupiter.api.BeforeAll}, {@link org.junit.jupiter.api.AfterEach} and {@link
+ * org.junit.jupiter.api.AfterAll} methods as parameter to get the current configuration for the
+ * test and a client configured to access the local S3 mock.
+ */
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(LocalS3Extension.class)
+public @interface S3Test {
+  @interface S3 {
+    /**
+     * @return property name of the access key used to connect to the local S3 mock
+     */
+    String accessKeyProperty() default "s3.accessKey";
+
+    /**
+     * @return property name of the secret key matching the {@linkplain #accessKeyProperty() access
+     *     key} used to connect to the local S3 mock
+     */
+    String secretKeyProperty() default "s3.secretKey";
+
+    /**
+     * @return property name of the endpoint in the form {@code http://localhost:<port>}, note that
+     *     {@link software.amazon.awssdk.services.s3.S3BaseClientBuilder#forcePathStyle(Boolean)}
+     *     must be {@code true}, otherwise, the client will use the bucket name as subdomain which
+     *     can't be resolved locally
+     */
+    String endpointProperty() default "s3.endpoint";
+
+    /**
+     * @return property name for the simulated AWS region of the local S3
+     */
+    String regionProperty() default "s3.region";
+
+    /**
+     * @return property name for the name of the bucket to be used in tests
+     */
+    String bucketNameProperty() default "s3.bucketName";
+  }
+
+  /**
+   * @return keys of {@linkplain System#setProperty(String, String) system properties} that
+   *     configure the applications S3 client
+   */
+  S3 configurationProperties() default @S3;
+
+  /**
+   * @return the name of the bucket to be used in tests
+   */
+  String bucketName() default "test-bucket";
+
+  /**
+   * @return if all objects in the S3 bucket should be removed in {@link
+   *     org.junit.jupiter.api.BeforeEach}
+   */
+  boolean cleanBeforeEach() default true;
+}


### PR DESCRIPTION
- [x] add tests for the extension itself -> via test in app-example
- [x] test and document dataPath -> did not work as expected -> config option removed