### PR TITLE
ci(maven-publish): remove redundant checksum files from .asc for published modules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,6 +106,7 @@ subprojects {
 
     mavenPublishing {
       publishToMavenCentral(true)
+      excludeSignatureChecksums(true)
       signAllPublications()
 
       pom {


### PR DESCRIPTION
Currently we also publish md5 and sha1 files for the artefact signature files in every modul
According to Maven Central, this is not necessar: https://central.sonatype.org/publish/requirements/#sign-files-with-gpgpgp
