### PR TITLE
Final dependency updates and CVE mitigation for Release 6.x.x

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -99,7 +99,7 @@ dependencies {
       because 'mixed versions with spring-boot managed 1.49.0 and opentelemetry-bom 1.62.0'
     }
 
-    api 'io.github.classgraph:classgraph:4.8.184'
+    api 'io.github.classgraph:classgraph:4.8.185'
     api 'javax.ws.rs:javax.ws.rs-api:2.1.1'
     api 'org.xerial.snappy:snappy-java:1.1.10.8', {
       because 'fix CVE-2023-34455, CVE-2023-43642'

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     }
     api "ch.qos.logback.contrib:logback-json-classic:${logbackContribVersion}"
     api "ch.qos.logback.contrib:logback-jackson:${logbackContribVersion}"
-    api 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.14'
+    api 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.17'
 
     // should align with transitive dependency of org.springdoc:springdoc-openapi-webmvc-core:
     api "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreVersion}"

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -129,7 +129,7 @@ dependencies {
 
     // sda-commons-starter-s3
     api "io.awspring.cloud:spring-cloud-aws-s3:3.4.2"
-    api "io.github.robothy:local-s3-rest:2.2"
+    api "io.github.robothy:local-s3-rest:2.4"
 
     api "org.apache.tomcat.embed:tomcat-embed-core:11.0.22", {
       because "CVE-2026-43512"

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -140,5 +140,9 @@ dependencies {
     api "org.apache.tomcat.embed:tomcat-embed-websocket:11.0.22", {
       because "CVE-2026-43512"
     }
+
+    api "at.yawk.lz4:lz4-java:1.11.1", {
+      because "CVE-2026-59949"
+    }
   }
 }

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -11,7 +11,7 @@ ext {
   logbackContribVersion = '0.1.5'
   // Check on upgrade, if org.apache.commons:commons-lang3 enforcement below (L25 + L58) is still needed!
   springBootVersion = '3.5.15' // CVE-2026-41731, CVE-2026-41726
-  nettyVersion = '4.1.135.Final'
+  nettyVersion = '4.1.136.Final'
   opentelemetryVersion = '1.62.0'
   // Check on upgrade, if commons-fileupload:commons-fileupload enforcement below (L67) is still needed!
   springCloudVersion = '2025.0.0'

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -10,7 +10,7 @@ ext {
   bouncycastleVersion = '1.84'
   logbackContribVersion = '0.1.5'
   // Check on upgrade, if org.apache.commons:commons-lang3 enforcement below (L25 + L58) is still needed!
-  springBootVersion = '3.5.15' // CVE-2026-41731, CVE-2026-41726
+  springBootVersion = '3.5.16' // CVE-2026-41731, CVE-2026-41726
   nettyVersion = '4.1.136.Final'
   opentelemetryVersion = '1.62.0'
   // Check on upgrade, if commons-fileupload:commons-fileupload enforcement below (L67) is still needed!

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -7,7 +7,7 @@ javaPlatform {
 }
 
 ext {
-  bouncycastleVersion = '1.84'
+  bouncycastleVersion = '1.85'
   logbackContribVersion = '0.1.5'
   // Check on upgrade, if org.apache.commons:commons-lang3 enforcement below (L25 + L58) is still needed!
   springBootVersion = '3.5.16' // CVE-2026-41731, CVE-2026-41726

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -17,7 +17,7 @@ ext {
   springCloudVersion = '2025.0.0'
   mongoDbDriverVersion = '5.6.3'
   scalaVersion = '2.13.18'
-  swaggerCoreVersion = '2.2.43'
+  swaggerCoreVersion = '2.2.52'
   victoolsVersion = '4.38.0'
 }
 


### PR DESCRIPTION
After merge:

- [x] Update release notes to clarify this is the last release for SDA Spring Boot Commons Version 6.
- [x]  Make branch release/6.x.x readonly
